### PR TITLE
uppercased() -> uppercaseString()

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Remember, a _method_ is just a function that is attached to a particular data ty
 
 Take a look at the autocomplete menu that appeared. All of the items in it are methods that you can call on `String`s. And what you see right now is only some of them! Don't worry what all of them do right now. For now, you're only interested in one that capitalizes your "Audrey" string.
 
-You can actually scroll this through this autocomplete popup. Use your mouse or trackpad to scroll through the list. Keep scrolling down until you get to the methods that start with **U**. You should see one that is called `uppercased()`. That looks like a winner!
+You can actually scroll this through this autocomplete popup. Use your mouse or trackpad to scroll through the list. Keep scrolling down until you get to the methods that start with **U**. You should see one that is called `uppercaseString()`. That looks like a winner!
 
 ![Autocomplete scrolling](http://i.imgur.com/TLGiFu3.png)
 
@@ -59,16 +59,16 @@ Now type `up`, so your line of code in your playground says `name.up`. You'll se
 
 ![Autocomplete: "up"](http://i.imgur.com/fMcGRRA.png)
 
-Make sure "uppercased()" is highlighted in the autocomplete menu and hit <kbd>Return</kbd>. Xcode will helpfully fill in the rest of the method name. (You could also type it out yourself, but why not let Xcode do all the boring work?)
+Make sure "uppercaseString()" is highlighted in the autocomplete menu and hit <kbd>Return</kbd>. Xcode will helpfully fill in the rest of the method name. (You could also type it out yourself, but why not let Xcode do all the boring work?)
 
 You've just called a method on your `String`! Notice in the playground sidebar that the return value of that method is "AUDREY". Your string has been capitalized!
 
 ![AUDREY](http://i.imgur.com/NWHxVHS.png)
 
-You can see this in action by printing the value of `name.uppercased()` to the playground's console. Try saving that return value in another constant and printing it out. Here's some code to help you that you can try out in your playground:
+You can see this in action by printing the value of `name.uppercaseString()` to the playground's console. Try saving that return value in another constant and printing it out. Here's some code to help you that you can try out in your playground:
 
 ```swift
-let uppercaseName = name.uppercased()
+let uppercaseName = name.uppercaseString()
 print("\(name)... \(name)... \(uppercaseName)! WAKE UP!")
 // prints "Audrey... Audrey... AUDREY! WAKE UP!")
 ```


### PR DESCRIPTION
I am not sure why this was changed from uppercaseString() to uppercased() but the correct swift method to uppercase a string is uppercaseString(). @annjohn @jim. 

Also can we remove the fork and pull request requirement for this readme.
